### PR TITLE
Fix README typo

### DIFF
--- a/READme.md
+++ b/READme.md
@@ -2,7 +2,7 @@
 
 This project uses machine learning (XGBoost model) to forecast hourly energy usage for the PJM Interconnection based on this Kaggle dataset https://www.kaggle.com/datasets/robikscube/hourly-energy-consumption.  
 
-The project contains an automatic pipeline for training and testing. It supports multi-horizon forecasting (up to x hours ahead) and tracks experiments with MLflow, currently for training and testing solely the XGBoostRegressor is included. This can be expanded with other models if and only if they are compatible with skicit-learn GridSearchCV.  
+The project contains an automatic pipeline for training and testing. It supports multi-horizon forecasting (up to x hours ahead) and tracks experiments with MLflow, currently for training and testing solely the XGBoostRegressor is included. This can be expanded with other models if and only if they are compatible with scikit-learn GridSearchCV.  
 The model is trained on lag features, see config.yaml for the lags included. Gridsearch is applied to find the best model, see the gridsearch parameters in config.yaml.  
 
 Todo: Add an inference pipeline, the functions are already included to conduct inference based on a registered model.  


### PR DESCRIPTION
## Summary
- correct spelling of `scikit-learn` in README

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a27015a88328b04591ce346419fe