### PR TITLE
Fix metrics plotting file save

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -121,7 +121,9 @@ class MetricsReporting:
             if show == True:
                 plt.show()
             if save == True:
-                plot_title = f"plots/metrics_{self.purpose}_horizons_{run_id}"
+                import os
+                os.makedirs("plots", exist_ok=True)
+                plot_title = f"plots/metrics_{self.purpose}_horizons_{run_id}.png"
                 plt.savefig(plot_title)
 
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -4,6 +4,7 @@ from sklearn.metrics import mean_squared_error, r2_score
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import os
 
 
 class MetricsReporting:
@@ -121,7 +122,6 @@ class MetricsReporting:
             if show == True:
                 plt.show()
             if save == True:
-                import os
                 os.makedirs("plots", exist_ok=True)
                 plot_title = f"plots/metrics_{self.purpose}_horizons_{run_id}.png"
                 plt.savefig(plot_title)


### PR DESCRIPTION
## Summary
- create plots/ directory if missing
- always save metrics plot as PNG

## Testing
- `pytest -q`
- `python pipeline_train_evaluate.py` *(fails: KeyboardInterrupt, heavy training)*

------
https://chatgpt.com/codex/tasks/task_e_6841a15b492c832892e3173f1af2b0a0